### PR TITLE
Added support for mapping doc entities

### DIFF
--- a/apifest-api/src/main/java/com/apifest/api/MappingDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingDocumentation.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2014, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apifest.api;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "mappings_docs")
+public class MappingDocumentation implements Serializable {
+
+    private static final long serialVersionUID = 8027603159873624488L;
+
+    @XmlAttribute(name = "version", required = true)
+    private String version;
+
+    @XmlElement(name = "endpoints", type = MappingEndpointDocumentation.class, required = true)
+    private List<MappingEndpointDocumentation> mappingEndpontDocumentation;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public MappingDocumentation() {
+        this.setMappingEndpontDocumentation(new ArrayList<MappingEndpointDocumentation>());
+    }
+
+    public List<MappingEndpointDocumentation> getMappingEndpontDocumentation() {
+        return mappingEndpontDocumentation;
+    }
+
+    public void setMappingEndpontDocumentation(List<MappingEndpointDocumentation> mappingEndpontDocumentation) {
+        this.mappingEndpontDocumentation = mappingEndpontDocumentation;
+    }
+}

--- a/apifest-api/src/main/java/com/apifest/api/MappingDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014, ApiFest project
+ * Copyright 2013-2015, ApiFest project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,11 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+/**
+ * A wrapper type that holds all the documentation for the mappings.
+ * @author Ivan Georgiev
+ *
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "mappings_docs")
 public class MappingDocumentation implements Serializable {
@@ -36,7 +41,7 @@ public class MappingDocumentation implements Serializable {
     private String version;
 
     @XmlElement(name = "endpoints", type = MappingEndpointDocumentation.class, required = true)
-    private List<MappingEndpointDocumentation> mappingEndpontDocumentation;
+    private List<MappingEndpointDocumentation> mappingEndpointDocumentation;
 
     public String getVersion() {
         return version;
@@ -47,14 +52,14 @@ public class MappingDocumentation implements Serializable {
     }
 
     public MappingDocumentation() {
-        this.setMappingEndpontDocumentation(new ArrayList<MappingEndpointDocumentation>());
+        this.setMappingEndpointDocumentation(new ArrayList<MappingEndpointDocumentation>());
     }
 
-    public List<MappingEndpointDocumentation> getMappingEndpontDocumentation() {
-        return mappingEndpontDocumentation;
+    public List<MappingEndpointDocumentation> getMappingEndpiontDocumentation() {
+        return mappingEndpointDocumentation;
     }
 
-    public void setMappingEndpontDocumentation(List<MappingEndpointDocumentation> mappingEndpontDocumentation) {
-        this.mappingEndpontDocumentation = mappingEndpontDocumentation;
+    public void setMappingEndpointDocumentation(List<MappingEndpointDocumentation> mappingEndpointDocumentation) {
+        this.mappingEndpointDocumentation = mappingEndpointDocumentation;
     }
 }

--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpoint.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpoint.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 /**
@@ -73,6 +74,9 @@ public class MappingEndpoint implements Serializable {
 
     @XmlElement(name = "filter", type = ResponseFilter.class)
     private ResponseFilter filter;
+
+    @XmlTransient
+    private boolean hidden;
 
     public MappingEndpoint() {
     }
@@ -179,6 +183,16 @@ public class MappingEndpoint implements Serializable {
 
     public void setBackendHost(String backendHost) {
         this.backendHost = backendHost;
+    }
+
+    public boolean isHidden()
+    {
+        return hidden;
+    }
+
+    public void setHidden(boolean hidden)
+    {
+        this.hidden = hidden;
     }
 
     /**

--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-2014, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apifest.api;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "endpoint_documentation")
+public class MappingEndpointDocumentation implements Serializable {
+
+    private static final long serialVersionUID = 4130570229846556297L;
+
+    @XmlAttribute(name = "scope", required = false)
+    private String scope;
+
+    @XmlAttribute(name = "method", required = true)
+    private String method;
+
+    @XmlAttribute(name = "endpoint", required = true)
+    private String endpoint;
+
+    @XmlAttribute(name = "description", required = true)
+    private String description;
+
+    @XmlAttribute(name = "summary", required = true)
+    private String summary;
+
+    @XmlAttribute(name = "group", required = true)
+    private String group;
+
+    @XmlElement(name = "params", type = MappingEndpointParamDocumentation.class)
+    private List<MappingEndpointParamDocumentation> mappingEndpontParamsDocumentation;
+
+    @XmlTransient
+    private boolean hidden;
+
+    public MappingEndpointDocumentation() {
+        this.mappingEndpontParamsDocumentation = new ArrayList<MappingEndpointParamDocumentation>();
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public List<MappingEndpointParamDocumentation> getMappingEndpontParamsDocumentation() {
+        return mappingEndpontParamsDocumentation;
+    }
+
+    public void setMappingEndpontParamsDocumentation(List<MappingEndpointParamDocumentation> mappingEndpontParamsDocumentation) {
+        this.mappingEndpontParamsDocumentation = mappingEndpontParamsDocumentation;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    public boolean isHidden() {
+        return hidden;
+    }
+
+    public void setHidden(boolean hidden) {
+        this.hidden = hidden;
+    }
+}

--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014, ApiFest project
+ * Copyright 2013-2015, ApiFest project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,11 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * A wrapper type that holds all the documentation an endpoint. 
+ * @author Ivan Georgiev
+ *
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "endpoint_documentation")
 public class MappingEndpointDocumentation implements Serializable {

--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpointParamDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpointParamDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014, ApiFest project
+ * Copyright 2013-2015, ApiFest project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * A wrapper type that holds the documentation for a endpoint parameter.
+ * @author Ivan Georgiev
+ *
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "endpoint_param_documentation")
 public class MappingEndpointParamDocumentation implements Serializable {

--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpointParamDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpointParamDocumentation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2013-2014, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apifest.api;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "endpoint_param_documentation")
+public class MappingEndpointParamDocumentation implements Serializable {
+
+    private static final long serialVersionUID = 2055836426063609094L;
+
+    @XmlAttribute(name = "type", required = true)
+    private String type;
+
+    @XmlAttribute(name = "name", required = true)
+    private String name;
+
+    @XmlAttribute(name = "required", required = true)
+    private boolean required;
+
+    public MappingEndpointParamDocumentation() {
+    }
+
+    public MappingEndpointParamDocumentation(String name, String type, boolean required) {
+        this.setName(name);
+        this.setType(type);
+        this.setRequired(required);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+}

--- a/apifest/src/main/java/com/apifest/GlobalErrorsConfigValidator.java
+++ b/apifest/src/main/java/com/apifest/GlobalErrorsConfigValidator.java
@@ -50,12 +50,13 @@ public final class GlobalErrorsConfigValidator {
         } else {
             throw new IllegalArgumentException("ERROR: schema file is not passed as arguments");
         }
-        String mappingFile = System.getProperty("global-errors.file");
-        if (mappingFile == null) {
-            throw new IllegalArgumentException("ERROR: mappings.file property not set");
+        String globalErrorsFile = System.getProperty("global-errors.file");
+        if (globalErrorsFile == null) {
+            throw new IllegalArgumentException("ERROR: global-errors.file property not set");
         } else {
-            ConfigValidator.validate(xsdFile, mappingFile);
+            ConfigValidator.validate(xsdFile, globalErrorsFile);
         }
+        log.info("global errors file {} is valid", globalErrorsFile);
     }
 
     public static boolean validate(File mappingFile) {
@@ -68,7 +69,7 @@ public final class GlobalErrorsConfigValidator {
             validator.validate(new StreamSource(mappingFile));
             ok = true;
         } catch (SAXException ex) {
-            log.error("mapping file NOT valid: {}", ex.getMessage());
+            log.error("global errors file NOT valid: {}", ex.getMessage());
         } catch (IOException e) {
             log.error("schema file not loaded: {}", e.getMessage());
         }

--- a/apifest/src/main/java/com/apifest/MappingConfigValidator.java
+++ b/apifest/src/main/java/com/apifest/MappingConfigValidator.java
@@ -56,6 +56,7 @@ public final class MappingConfigValidator {
         } else {
             ConfigValidator.validate(xsdFile, mappingFile);
         }
+        log.info("mapping file {} is valid", mappingFile);
     }
 
     public static boolean validate(File mappingFile) {


### PR DESCRIPTION
The project now contains entities used by the apifest-doclet project to generate documentation based on documentation tags.