### PR TITLE
[RA-191] Implementation of OAuth through ApiFest for File Download

### DIFF
--- a/apifest/src/main/java/com/apifest/AccessTokenValidator.java
+++ b/apifest/src/main/java/com/apifest/AccessTokenValidator.java
@@ -36,6 +36,7 @@ import com.google.gson.JsonParser;
 public class AccessTokenValidator {
 
     private static final Pattern AUTH_BEARER_PATTERN = Pattern.compile("(Bearer )(\\w*)");
+    private static final Pattern AUTH_QUERY_PARAM = Pattern.compile("(access_token=)(\\w*)");
 
     protected static Logger log = LoggerFactory.getLogger(AccessTokenValidator.class);
 
@@ -74,6 +75,10 @@ public class AccessTokenValidator {
 
     protected static String extractAccessToken(String header) {
         Matcher m = AUTH_BEARER_PATTERN.matcher(header);
+        if (m.find()) {
+            return m.group(2);
+        }
+        m = AUTH_QUERY_PARAM.matcher(header);
         if (m.find()) {
             return m.group(2);
         }

--- a/apifest/src/main/java/com/apifest/HttpRequestHandler.java
+++ b/apifest/src/main/java/com/apifest/HttpRequestHandler.java
@@ -117,7 +117,9 @@ public class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                             break;
                         }
                     }
-
+                    if(accessToken == null) {
+                        accessToken = AccessTokenValidator.extractAccessToken(uri);
+                    }
                     if (accessToken == null) {
                         writeResponseToChannel(channel, req, HttpResponseFactory.createUnauthorizedResponse(ACCESS_TOKEN_REQUIRED));
                         return;


### PR DESCRIPTION
We needed to pass the authorization token aside of OAuth2 described way.
This is needed so the file download could work with AJAX.
One solution was passing the access_token as a query parameter on any apifest endpoint.