### PR TITLE
Support for documenting request params, result params and exceptions of the endpoints.

### DIFF
--- a/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/MappingEndpointDocumentation.java
@@ -27,8 +27,12 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
+import com.apifest.api.params.ExceptionDocumentation;
+import com.apifest.api.params.RequestParamDocumentation;
+import com.apifest.api.params.ResultParamDocumentation;
+
 /**
- * A wrapper type that holds all the documentation an endpoint. 
+ * A wrapper type that holds all the documentation an endpoint.
  * @author Ivan Georgiev
  *
  */
@@ -50,20 +54,41 @@ public class MappingEndpointDocumentation implements Serializable {
     @XmlAttribute(name = "description", required = true)
     private String description;
 
+    @XmlAttribute(name = "paramsDescription", required = true)
+    private String paramsDescription;
+
+    @XmlAttribute(name = "resultsDescription", required = true)
+    private String resultsDescription;
+
     @XmlAttribute(name = "summary", required = true)
     private String summary;
 
     @XmlAttribute(name = "group", required = true)
     private String group;
 
-    @XmlElement(name = "params", type = MappingEndpointParamDocumentation.class)
-    private List<MappingEndpointParamDocumentation> mappingEndpontParamsDocumentation;
+    @XmlTransient
+    private int order;
+
+    @XmlElement(name = "requestParams", type = RequestParamDocumentation.class)
+    private List<RequestParamDocumentation> requestParamsDocumentation;
+
+    @XmlElement(name = "resultParams", type = RequestParamDocumentation.class)
+    private List<ResultParamDocumentation> resultParamsDocumentation;
+
+    @XmlElement(name = "exceptions", type = ExceptionDocumentation.class)
+    private List<ExceptionDocumentation> exceptionsDocumentation;
+
+    @XmlElement(name="exampleRequest")
+    private String exampleRequest;
+
+    @XmlElement(name="exampleResult")
+    private String exampleResult;
 
     @XmlTransient
     private boolean hidden;
 
     public MappingEndpointDocumentation() {
-        this.mappingEndpontParamsDocumentation = new ArrayList<MappingEndpointParamDocumentation>();
+        this.requestParamsDocumentation = new ArrayList<RequestParamDocumentation>();
     }
 
     public String getScope() {
@@ -90,12 +115,24 @@ public class MappingEndpointDocumentation implements Serializable {
         this.endpoint = endpoint;
     }
 
-    public List<MappingEndpointParamDocumentation> getMappingEndpontParamsDocumentation() {
-        return mappingEndpontParamsDocumentation;
+    public List<RequestParamDocumentation> getRequestParamsDocumentation()
+    {
+        return requestParamsDocumentation;
     }
 
-    public void setMappingEndpontParamsDocumentation(List<MappingEndpointParamDocumentation> mappingEndpontParamsDocumentation) {
-        this.mappingEndpontParamsDocumentation = mappingEndpontParamsDocumentation;
+    public void setRequestParamsDocumentation(List<RequestParamDocumentation> requestParamsDocumentation)
+    {
+        this.requestParamsDocumentation = requestParamsDocumentation;
+    }
+
+    public List<ResultParamDocumentation> getResultParamsDocumentation()
+    {
+        return resultParamsDocumentation;
+    }
+
+    public void setResultParamsDocumentation(List<ResultParamDocumentation> resultParamsDocumentation)
+    {
+        this.resultParamsDocumentation = resultParamsDocumentation;
     }
 
     public String getDescription() {
@@ -104,6 +141,26 @@ public class MappingEndpointDocumentation implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getParamsDescription()
+    {
+        return paramsDescription;
+    }
+
+    public void setParamsDescription(String paramsDescription)
+    {
+        this.paramsDescription = paramsDescription;
+    }
+
+    public String getResultsDescription()
+    {
+        return resultsDescription;
+    }
+
+    public void setResultsDescription(String resultsDescription)
+    {
+        this.resultsDescription = resultsDescription;
     }
 
     public String getSummary() {
@@ -122,11 +179,51 @@ public class MappingEndpointDocumentation implements Serializable {
         this.group = group;
     }
 
+    public int getOrder()
+    {
+        return order;
+    }
+
+    public void setOrder(int order)
+    {
+        this.order = order;
+    }
+
     public boolean isHidden() {
         return hidden;
     }
 
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
+    }
+
+    public List<ExceptionDocumentation> getExceptionsDocumentation()
+    {
+        return exceptionsDocumentation;
+    }
+
+    public void setExceptionsDocumentation(List<ExceptionDocumentation> exceptionsDocumentation)
+    {
+        this.exceptionsDocumentation = exceptionsDocumentation;
+    }
+
+    public String getExampleRequest()
+    {
+        return exampleRequest;
+    }
+
+    public void setExampleRequest(String exampleRequest)
+    {
+        this.exampleRequest = exampleRequest;
+    }
+
+    public String getExampleResult()
+    {
+        return exampleResult;
+    }
+
+    public void setExampleResult(String exampleResult)
+    {
+        this.exampleResult = exampleResult;
     }
 }

--- a/apifest-api/src/main/java/com/apifest/api/params/ExceptionDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/params/ExceptionDocumentation.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apifest.api.params;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+
+/**
+ * A POJO which holds the information for expected errors or exceptions when invoking the API.
+ * @author Martin Boyanov
+ *
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ExceptionDocumentation implements Serializable
+{
+
+    private static final long serialVersionUID = 3886830353468804316L;
+
+    @XmlAttribute(name = "name", required = true)
+    private String name;
+
+    @XmlAttribute(name = "condition", required = true)
+    private String condition;
+
+    @XmlAttribute(name = "description", required = true)
+    private String description;
+
+    @XmlAttribute(name = "code", required = true)
+    private Integer code;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String name)
+    {
+        this.name = name;
+    }
+
+    public String getCondition()
+    {
+        return condition;
+    }
+
+    public void setCondition(String condition)
+    {
+        this.condition = condition;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String description)
+    {
+        this.description = description;
+    }
+
+    public Integer getCode()
+    {
+        return code;
+    }
+
+    public void setCode(Integer code)
+    {
+        this.code = code;
+    }
+}

--- a/apifest-api/src/main/java/com/apifest/api/params/RequestParamDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/params/RequestParamDocumentation.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.apifest.api;
+package com.apifest.api.params;
 
 import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
 
 /**
  * A wrapper type that holds the documentation for a endpoint parameter.
@@ -29,8 +28,7 @@ import javax.xml.bind.annotation.XmlType;
  *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "endpoint_param_documentation")
-public class MappingEndpointParamDocumentation implements Serializable {
+public class RequestParamDocumentation implements Serializable {
 
     private static final long serialVersionUID = 2055836426063609094L;
 
@@ -40,13 +38,19 @@ public class MappingEndpointParamDocumentation implements Serializable {
     @XmlAttribute(name = "name", required = true)
     private String name;
 
+    @XmlAttribute(name = "description", required = true)
+    private String description;
+
     @XmlAttribute(name = "required", required = true)
     private boolean required;
 
-    public MappingEndpointParamDocumentation() {
+    @XmlAttribute(name="exampleValue")
+    private String exampleValue;
+
+    public RequestParamDocumentation() {
     }
 
-    public MappingEndpointParamDocumentation(String name, String type, boolean required) {
+    public RequestParamDocumentation(String name, String type, boolean required) {
         this.setName(name);
         this.setType(type);
         this.setRequired(required);
@@ -68,6 +72,16 @@ public class MappingEndpointParamDocumentation implements Serializable {
         this.name = name;
     }
 
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String description)
+    {
+        this.description = description;
+    }
+
     public boolean isRequired() {
         return required;
     }
@@ -75,4 +89,15 @@ public class MappingEndpointParamDocumentation implements Serializable {
     public void setRequired(boolean required) {
         this.required = required;
     }
+
+    public String getExampleValue()
+    {
+        return exampleValue;
+    }
+
+    public void setExampleValue(String exampleValue)
+    {
+        this.exampleValue = exampleValue;
+    }
+
 }

--- a/apifest-api/src/main/java/com/apifest/api/params/ResultParamDocumentation.java
+++ b/apifest-api/src/main/java/com/apifest/api/params/ResultParamDocumentation.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2015, ApiFest project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.apifest.api.params;
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ * A wrapper type that holds the documentation for a endpoint result parameter.
+ * @author Martin Boyanov
+ *
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ResultParamDocumentation implements Serializable {
+
+    private static final long serialVersionUID = -5373720410834445877L;
+
+    @XmlAttribute(name = "type", required = true)
+    private String type;
+
+    @XmlAttribute(name = "name", required = true)
+    private String name;
+
+    @XmlAttribute(name = "description", required = true)
+    private String description;
+
+    @XmlAttribute(name = "required", required = true)
+    private boolean required;
+
+    public ResultParamDocumentation() {
+    }
+
+    public ResultParamDocumentation(String name, String type, boolean required) {
+        this.setName(name);
+        this.setType(type);
+        this.setRequired(required);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String description)
+    {
+        this.description = description;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+}


### PR DESCRIPTION
MappingEndpointDocumentation now has lists for the request params, result params and expected errors.
These POJOs serve for the apifest-doclet documentation generation.
Also, each endpoint now has an order property which can be used to order the output of the apifest doclet.