### PR TITLE
[Issue #43] Expect: 100 Continue / incorrect processing

### DIFF
--- a/apifest/src/main/java/com/apifest/HttpResponseHandler.java
+++ b/apifest/src/main/java/com/apifest/HttpResponseHandler.java
@@ -18,6 +18,7 @@ package com.apifest;
 
 import java.net.ConnectException;
 
+import org.apache.http.HttpStatus;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -48,9 +49,13 @@ public class HttpResponseHandler extends SimpleChannelUpstreamHandler {
             response = (HttpResponse) e.getMessage();
             statusCode = response.getStatus().getCode();
         }
-
         Channel channel = ctx.getChannel();
-        channel.close();
+        // do not close the channel if 100 Continue
+        if (statusCode != null && statusCode.intValue() == HttpStatus.SC_CONTINUE) {
+            //do not close the channel
+        } else {
+            channel.close();
+        }
         if(ctx.getAttachment() instanceof TokenValidationListener) {
             TokenValidationListener listener = (TokenValidationListener) ctx.getAttachment();
             listener.responseReceived(response);

--- a/apifest/src/main/java/com/apifest/HttpResponseHandler.java
+++ b/apifest/src/main/java/com/apifest/HttpResponseHandler.java
@@ -51,9 +51,7 @@ public class HttpResponseHandler extends SimpleChannelUpstreamHandler {
         }
         Channel channel = ctx.getChannel();
         // do not close the channel if 100 Continue
-        if (statusCode != null && statusCode.intValue() == HttpStatus.SC_CONTINUE) {
-            //do not close the channel
-        } else {
+        if ((statusCode == null) || (statusCode != null && statusCode.intValue() != HttpStatus.SC_CONTINUE)) {
             channel.close();
         }
         if(ctx.getAttachment() instanceof TokenValidationListener) {


### PR DESCRIPTION
When the backend server responses with HTTP 100-Continue, do not close the channel.